### PR TITLE
Sleep time

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.11.2",
     "@fortawesome/react-fontawesome": "^0.1.7",
     "axios": "^0.19.0",
+    "dayjs": "^1.8.17",
     "jwt-decode": "^2.2.0",
     "react": "^16.11.0",
     "react-date-picker": "^7.8.2",

--- a/src/components/SleepTime.js
+++ b/src/components/SleepTime.js
@@ -1,0 +1,44 @@
+import React, { useState, useEffect } from "react"
+import axios from "../utils/axiosWithAuth"
+import dayjs from "dayjs"
+
+export default function SleepTime() {
+  const [hasEnoughEntries, setHasEnoughEntries] = useState(false)
+  const [optimal, setOptimal] = useState("more")
+  const [sleepData, setSleepData] = useState()
+  let data = []
+
+  useEffect(() => {
+    axios()
+      .get("/api/users/sleepdata")
+      .then(res => {
+        setSleepData(res.data)
+      })
+  }, [])
+
+  useEffect(() => {
+    sleepData && sleepData.length > 2 && setHasEnoughEntries(true)
+
+    sleepData &&
+      sleepData.map(entry => {
+        data.push(
+          dayjs(entry.dateTimeTo).diff(dayjs(entry.dateTimeFrom), "hour")
+        )
+      })
+    setOptimal(
+      data.length > 0 &&
+        data.reduce((prev, curr) => {
+          return (curr += prev)
+        }) / data.length
+    )
+  }, [sleepData])
+
+  return (
+    <div>
+      {!hasEnoughEntries && <p>Doesn't have enough entries!</p>}
+      {hasEnoughEntries && (
+        <p>{`Your optimal sleep time is ${optimal} hours`}</p>
+      )}
+    </div>
+  )
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3263,6 +3263,11 @@ data-urls@^1.0.0, data-urls@^1.1.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
+dayjs@^1.8.17:
+  version "1.8.17"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.8.17.tgz#53ec413f2a7b02afbea1846d61bb260fa8567cea"
+  integrity sha512-47VY/htqYqr9GHd7HW/h56PpQzRBSJcxIQFwqL3P20bMF/3az5c3PWdVY3LmPXFl6cQCYHL7c79b9ov+2bOBbw==
+
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
Behind the scenes, a score 1-4 is given for each emoji. The app will calculate an average mood score for 1/2/19, and compare it to the time spent in bed. The app will then recommend after using for >1 month how much sleep you need. “Your mood score tends to be highest when you sleep 7.5 hours”